### PR TITLE
Revert "Bump rclone/rclone from 1.65.2 to 1.66.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rclone/rclone:1.66.0
+FROM rclone/rclone:1.65.2
 EXPOSE 8080
 RUN apk add --update --no-cache wget openjdk17-jre-headless
 ADD /target/rclone-watchdog.jar rclone-watchdog.jar

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.massaro</groupId>
     <artifactId>rclone-watchdog</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.3</version>
+    <version>1.5.4</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Getting an SFTP error that says this:

```
Failed to sync: optional feature not implemented
```

when running on 1.66.0.

Reverts StevenMassaro/rclone-watchdog#207